### PR TITLE
Fix chain_id format in foundry.toml for forge test compatibility

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,6 @@ libs = ["lib"]
 
 # Monad Configuration
 eth-rpc-url="https://testnet-rpc.monad.xyz"
-chain_id = "10143"
+chain_id = 10143
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
### Summary
Fixed `chain_id` format in `foundry.toml` to prevent forge test failure.

### Changes
- Changed `chain_id = "10143"` to `chain_id = 10143`
- This resolves the error: "invalid type: found string, expected u64"

### Testing
Ran `forge test`, all tests passed successfully.